### PR TITLE
fix: make microchip search independent from form submit

### DIFF
--- a/src/components/Events/Formv3.tsx
+++ b/src/components/Events/Formv3.tsx
@@ -55,7 +55,6 @@ const FormV3 = ({
   const thaiDate = parseThaiDate(new Date(deadline).getTime());
   const { replace } = useRouter();
   const [calculatedAge, setCalculatedAge] = useState<number>(0);
-  const [inputMicrochip, setInputMicrochip] = useState<string>();
   const [autoAssignedClass, setAutoAssignedClass] = useState<{
     competitionLevel: string | null;
     competitionType: string | null;
@@ -105,6 +104,7 @@ const FormV3 = ({
     watch,
     reset,
     setValue,
+    getValues,
   } = useForm<EventRegisterType>();
 
   const handleToggleManualMode = useCallback((manual: boolean) => {
@@ -175,8 +175,12 @@ const FormV3 = ({
   });
 
   const handleSearchMetadata = () => {
-    if (inputMicrochip == undefined) return;
-    search({ microchip: inputMicrochip });
+    const microchipValue = getValues("microchip")?.trim();
+    if (!microchipValue) {
+      alert("กรุณากรอกเลขไมโครชิพก่อนค้นหา");
+      return;
+    }
+    search({ microchip: microchipValue });
   };
 
   const handleBirthDateChange = useCallback((isoDate: string) => {
@@ -188,7 +192,7 @@ const FormV3 = ({
     const subscription = watch((value, { name, type }) => {
       // Only execute logic if the changed field is buffaloBirthDate or microchip
       if (name === 'buffaloBirthDate' || name === 'microchip') {
-        const { buffaloBirthDate, microchip } = value;
+        const { buffaloBirthDate } = value;
         if (!buffaloBirthDate) return;
         
         const start = dayjs(buffaloBirthDate);
@@ -202,7 +206,6 @@ const FormV3 = ({
         }
 
         setCalculatedAge(diff);
-        setInputMicrochip(microchip!);
         
         // Reset manual mode whenever birthday changes (to try auto-assign first)
         // But ONLY if it was triggered by user input, not programmatic set
@@ -355,6 +358,7 @@ const FormV3 = ({
                   </label>
                 </div>
                 <button
+                  type="button"
                   disabled={searching || isLoading}
                   onClick={() => handleSearchMetadata()}
                   className="btn btn-primary btn-sm"


### PR DESCRIPTION
This pull request refactors how the microchip input is handled in the `FormV3` component, streamlining form state management and improving user experience. The changes eliminate redundant state, rely more on `react-hook-form` utilities, and add validation for the microchip search functionality.

Form state management improvements:

* Removed the `inputMicrochip` local state and now directly access the microchip value using `getValues` from `react-hook-form`, reducing unnecessary state and simplifying logic. [[1]](diffhunk://#diff-2ec44f66386a13caf625d64301403ab88fe54c37f4dc382d223fc87d8caa300aL58) [[2]](diffhunk://#diff-2ec44f66386a13caf625d64301403ab88fe54c37f4dc382d223fc87d8caa300aR107)
* Updated the `handleSearchMetadata` function to validate the microchip input, showing an alert if the field is empty before searching. This prevents unnecessary search requests and guides the user.

Code simplification:

* Refactored the form watcher to remove dependency on the local `inputMicrochip` state and rely solely on form values, making the code more maintainable. [[1]](diffhunk://#diff-2ec44f66386a13caf625d64301403ab88fe54c37f4dc382d223fc87d8caa300aL191-R195) [[2]](diffhunk://#diff-2ec44f66386a13caf625d64301403ab88fe54c37f4dc382d223fc87d8caa300aL205)

UI improvement:

* Added `type="button"` to the search button to prevent accidental form submission, improving usability.